### PR TITLE
 Introduce Persistence strategy

### DIFF
--- a/app/Infrastructure/Persistence/Todo/Eloquent/EloquentTodoRepository.php
+++ b/app/Infrastructure/Persistence/Todo/Eloquent/EloquentTodoRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Todo\Eloquent;
+
+use App\Domain\Todo\Entity\Todo;
+use App\Domain\Todo\TodoRepository;
+use App\Infrastructure\Persistence\Todo\Eloquent\Models\TodoModel;
+use App\Infrastructure\Persistence\Todo\Eloquent\Mappers\TodoModelToEntity;
+use App\Infrastructure\Persistence\Todo\Eloquent\Mappers\EntityToTodoModel;
+
+final class EloquentTodoRepository implements TodoRepository
+{
+    public function save(Todo $todo): void
+    {
+        $model = EntityToTodoModel::map($todo);
+        $model->save();
+    }
+
+    /** @return Todo[] */
+    public function findAll(): array
+    {
+        return TodoModel::all()
+            ->map(fn(TodoModel $m) => TodoModelToEntity::map($m))
+            ->all();
+    }
+
+    public function findById(string $id): ?Todo
+    {
+        $m = TodoModel::find($id);
+        return $m ? TodoModelToEntity::map($m) : null;
+    }
+
+    public function update(Todo $todo): ?Todo
+    {
+        $m = TodoModel::find($todo->getId()->toString());
+        if (!$m) {
+            return null;
+        }
+        $m->title = $todo->getTitle();
+        $m->completed = $todo->isCompleted();
+        $m->save();
+
+        return TodoModelToEntity::map($m);
+    }
+
+    public function delete(string $id): void
+    {
+        TodoModel::destroy($id);
+    }
+}

--- a/app/Infrastructure/Persistence/Todo/Eloquent/Mappers/EntityToTodoModel.php
+++ b/app/Infrastructure/Persistence/Todo/Eloquent/Mappers/EntityToTodoModel.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Infrastructure\Persistence\Todo\Eloquent\Mappers;
+
+use App\Domain\Todo\Entity\Todo;
+use App\Infrastructure\Persistence\Todo\Eloquent\Models\TodoModel;
+
+final class EntityToTodoModel
+{
+    public static function map(Todo $todo): TodoModel
+    {
+        $model = new TodoModel();
+
+        $model->setRawAttributes([
+            'id'        => $todo->getId()->toString(),
+            'title'     => $todo->getTitle(),
+            'completed' => $todo->isCompleted(),
+        ], /* syncOriginal = */ true);
+
+        return $model;
+    }
+}

--- a/app/Infrastructure/Persistence/Todo/Eloquent/Mappers/TodoModelToEntity.php
+++ b/app/Infrastructure/Persistence/Todo/Eloquent/Mappers/TodoModelToEntity.php
@@ -1,0 +1,20 @@
+<?php
+namespace App\Infrastructure\Persistence\Todo\Eloquent\Mappers;
+
+use App\Domain\Todo\Entity\Todo;
+use App\Infrastructure\Persistence\Todo\Eloquent\Models\TodoModel;
+
+final class TodoModelToEntity
+{
+    public static function map(TodoModel $m): Todo
+    {
+        return Todo::reconstruct(
+            id:        $m->id,
+            title:     $m->title,
+            completed: $m->completed,
+            createdAt: $m->created_at instanceof \DateTimeImmutable
+                ? $m->created_at
+                : $m->created_at->toDateTimeImmutable(),
+        );
+    }
+}

--- a/app/Infrastructure/Persistence/Todo/Eloquent/Models/TodoModel.php
+++ b/app/Infrastructure/Persistence/Todo/Eloquent/Models/TodoModel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Infrastructure\Persistence\Todo\Eloquent\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+class TodoModel extends Model
+{
+    use HasUuids;
+
+    protected $table = 'todos';
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'title',
+        'completed',
+    ];
+
+    protected $casts = [
+        'completed'  => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+}

--- a/app/Infrastructure/Persistence/Todo/File/FileTodoRepository.php
+++ b/app/Infrastructure/Persistence/Todo/File/FileTodoRepository.php
@@ -1,0 +1,132 @@
+<?php
+namespace App\Infrastructure\Persistence\Todo\File;
+
+use App\Domain\Todo\Entity\Todo;
+use App\Domain\Todo\TodoRepository;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
+
+final class FileTodoRepository implements TodoRepository
+{
+    private FilesystemAdapter $disk;
+    private string $path = 'todos.json';
+
+    public function __construct()
+    {
+        $this->disk = Storage::disk('local');
+
+        if (! $this->disk->exists($this->path)) {
+            $this->disk->put($this->path, json_encode([], JSON_PRETTY_PRINT));
+        }
+    }
+
+    private function readFile(): array
+    {
+        $content = $this->disk->get($this->path);
+
+        return json_decode($content, true) ?: [];
+    }
+
+    private function writeFile(array $data): void
+    {
+        $this->disk->put($this->path, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    public function save(Todo $todo): void
+    {
+        $all = $this->readFile();
+
+        $all['todos'][] = [
+            'id'        => $todo->getId()->toString(),
+            'title'     => $todo->getTitle(),
+            'completed' => $todo->isCompleted(),
+            'createdAt' => $todo->getCreatedAt()->format(\DateTime::ATOM),
+        ];
+
+        $this->writeFile($all);
+    }
+
+    /**
+     * @return Todo[]
+     */
+    public function findAll(): array
+    {
+        $all = $this->readFile();
+
+        return array_map(function(array $item) {
+            return Todo::reconstruct(
+                $item['id'],
+                $item['title'],
+                $item['completed'],
+                new \DateTimeImmutable($item['createdAt'])
+            );
+        }, array_values($all['todos']));
+    }
+
+    public function findById(string $id): ?Todo
+    {
+        $all = $this->readFile();
+
+        $filtered = array_find(
+            $all['todos'],
+            fn(array $item) => $item['id'] === $id
+        );
+
+        if (!$filtered) {
+            return null;
+        }
+
+        return Todo::reconstruct(
+            $filtered['id'],
+            $filtered['title'],
+            $filtered['completed'],
+            new \DateTimeImmutable($filtered['createdAt'])
+        );
+    }
+
+    public function update(Todo $todo): ?Todo
+    {
+        $all = $this->readFile();
+
+        $filtered = array_find(
+            $all['todos'],
+            fn(array $item) => $item['id'] === $todo->getId()->toString()
+        );
+
+        if (!$filtered) {
+            return null;
+        }
+
+        $filtered['title'] = $todo->getTitle();
+        $filtered['completed'] = $todo->isCompleted();
+
+        $all['todos'] = array_map(
+            fn(array $item) => $item['id'] === $todo->getId()->toString() ? $filtered : $item,
+            $all['todos']
+        );
+
+        $this->writeFile($all);
+
+        return Todo::reconstruct(
+            $filtered['id'],
+            $filtered['title'],
+            $filtered['completed'],
+            new \DateTimeImmutable($filtered['createdAt'])
+        );
+    }
+
+
+    public function delete(string $id): void
+    {
+        $all = $this->readFile();
+
+        $filtered = array_filter(
+            $all['todos'],
+            fn(array $item) => $item['id'] !== $id
+        );
+
+        $all['todos'] = $filtered;
+
+        $this->writeFile($all);
+    }
+}

--- a/app/Infrastructure/Persistence/User/Eloquent/Models/User.php
+++ b/app/Infrastructure/Persistence/User/Eloquent/Models/User.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+// use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    /** @use HasFactory<\Database\Factories\UserFactory> */
+    use HasFactory, Notifiable;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+        ];
+    }
+}


### PR DESCRIPTION
This pull request introduces two new persistence strategies for managing `Todo` entities: one using Eloquent ORM and another using a file-based approach. Additionally, it includes the creation of necessary models and mappers for the Eloquent implementation and a new `User` model. Below are the key changes grouped by theme:

### Eloquent-based Persistence for `Todo`:

* **Eloquent Repository Implementation**: Added `EloquentTodoRepository` to handle CRUD operations for `Todo` entities using Eloquent ORM. This includes methods like `save`, `findAll`, `findById`, `update`, and `delete`. (`app/Infrastructure/Persistence/Todo/Eloquent/EloquentTodoRepository.php`)
* **Model and Mappers**:
  - Added `TodoModel` to represent the database table `todos`. It includes UUID support, attribute casting, and mass assignment configuration. (`app/Infrastructure/Persistence/Todo/Eloquent/Models/TodoModel.php`)
  - Added `EntityToTodoModel` and `TodoModelToEntity` mappers to convert between `Todo` entities and `TodoModel` instances. (`app/Infrastructure/Persistence/Todo/Eloquent/Mappers/EntityToTodoModel.php`, `app/Infrastructure/Persistence/Todo/Eloquent/Mappers/TodoModelToEntity.php`) [[1]](diffhunk://#diff-048c1925550b25e90b51a4fc04d2c89b0a2066e607b75cdf366131b719b03ce0R1-R21) [[2]](diffhunk://#diff-767c175461ddf1e3e9ec3921e2143a179aef338f65306fa870ef731870121fbcR1-R20)

### File-based Persistence for `Todo`:

* **File Repository Implementation**: Added `FileTodoRepository` to manage `Todo` entities using a JSON file. Includes methods for reading and writing the file, as well as CRUD operations. (`app/Infrastructure/Persistence/Todo/File/FileTodoRepository.php`)

### User Model:

* **User Model Creation**: Added a `User` model with attributes for mass assignment, hidden fields, and type casting. This model extends Laravel's `Authenticatable` class and includes factory and notification traits. (`app/Infrastructure/Persistence/User/Eloquent/Models/User.php`)