### PR TITLE
Add unit and integration tests

### DIFF
--- a/tests/Integration/Todo/EloquentTodoRepositoryTest.php
+++ b/tests/Integration/Todo/EloquentTodoRepositoryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Integration\Repositories;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Infrastructure\Persistence\Todo\Eloquent\EloquentTodoRepository;
+use App\Domain\Todo\Entity\Todo;
+
+class EloquentTodoRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testShouldCreateTodo(): void
+    {
+        // Récupère l’implémentation Eloquent du repository
+        /** @var EloquentTodoRepository $repo */
+        $repo = $this->app->make(EloquentTodoRepository::class);
+
+        $todo = Todo::create('Intégration 1');
+        $repo->save($todo);
+
+        $this->assertNotNull($todo);
+        $this->assertSame('Intégration 1', $todo->getTitle());
+    }
+
+    public function testShouldFindAllTodos(): void
+    {
+        // Récupère l’implémentation Eloquent du repository
+        /** @var EloquentTodoRepository $repo */
+        $repo = $this->app->make(EloquentTodoRepository::class);
+
+        $todo1 = Todo::create('Intégration 1');
+        $todo2 = Todo::create('Intégration 2');
+
+        $repo->save($todo1);
+        $repo->save($todo2);
+
+        $all = $repo->findAll();
+        $this->assertCount(2, $all);
+        $this->assertSame($todo1->getId()->toString(), $all[0]->getId()->toString());
+        $this->assertSame($todo2->getId()->toString(), $all[1]->getId()->toString());
+    }
+
+    public function testShouldFindById(): void
+    {
+        // Récupère l’implémentation Eloquent du repository
+        /** @var EloquentTodoRepository $repo */
+        $repo = $this->app->make(EloquentTodoRepository::class);
+
+        $todo = Todo::create('Intégration 1');
+        $repo->save($todo);
+
+        $found = $repo->findById($todo->getId()->toString());
+        $this->assertNotNull($found);
+        $this->assertSame($todo->getId()->toString(), $found->getId()->toString());
+        $this->assertSame('Intégration 1', $found->getTitle());
+    }
+
+    public function testShouldMarkTodoAsCompleted(): void
+    {
+        // Récupère l’implémentation Eloquent du repository
+        /** @var EloquentTodoRepository $repo */
+        $repo = $this->app->make(EloquentTodoRepository::class);
+
+        $todo = Todo::create('Intégration 1');
+        $repo->save($todo);
+
+        $todo->markAsCompleted();
+        $repo->update($todo);
+
+        $updated = $repo->findById($todo->getId()->toString());
+        $this->assertTrue($updated->isCompleted());
+    }
+
+    public function testShouldDeleteTodo(): void
+    {
+        $repo = $this->app->make(EloquentTodoRepository::class);
+
+        $todo = Todo::create('Intégration 1');
+        $repo->save($todo);
+
+        $repo->delete($todo->getId()->toString());
+
+        $this->assertNull($repo->findById($todo->getId()->toString()));
+    }
+}

--- a/tests/Integration/Todo/FileTodoRepositoryTest.php
+++ b/tests/Integration/Todo/FileTodoRepositoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Integration\Repositories;
+
+use Tests\TestCase;
+use App\Domain\Todo\Entity\Todo;
+use App\Infrastructure\Persistence\Todo\File\FileTodoRepository;
+use Illuminate\Support\Facades\Storage;
+
+class FileTodoRepositoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    public function testShouldCreateTodo(): void
+    {
+        $repo = $this->app->make(FileTodoRepository::class);
+
+        $todo = Todo::create('Intégration 1');
+        $repo->save($todo);
+
+        $found = $repo->findById($todo->getId()->toString());
+        $this->assertNotNull($found);
+        $this->assertEquals($todo->getTitle(), $found->getTitle());
+    }
+
+    public function testShouldFindAllTodos(): void
+    {
+        $repo = $this->app->make(FileTodoRepository::class);
+
+        $todo1 = Todo::create('Intégration 1');
+        $todo2 = Todo::create('Intégration 2');
+
+        $repo->save($todo1);
+        $repo->save($todo2);
+
+        $all = $repo->findAll();
+        $this->assertCount(2, $all);
+        $this->assertSame($todo1->getId()->toString(), $all[0]->getId()->toString());
+        $this->assertSame($todo2->getId()->toString(), $all[1]->getId()->toString());
+    }
+
+    public function testShouldFindById(): void
+    {
+        $repo = $this->app->make(FileTodoRepository::class);
+
+        $todo = Todo::create('À trouver');
+        $repo->save($todo);
+
+        $found = $repo->findById($todo->getId()->toString());
+        $this->assertNotNull($found);
+        $this->assertEquals($todo->getTitle(), $found->getTitle());
+    }
+
+    public function testShouldMarkTodoAsCompleted(): void
+    {
+        $repo = $this->app->make(FileTodoRepository::class);
+
+        $todo = Todo::create('À compléter');
+        $repo->save($todo);
+
+        $todo->markAsCompleted();
+        $repo->update($todo);
+
+        $updated = $repo->findById($todo->getId()->toString());
+        $this->assertTrue($updated->isCompleted());
+    }
+
+    public function testShouldDeleteTodo(): void
+    {
+        $repo = $this->app->make(FileTodoRepository::class);
+
+        $todo = Todo::create('À supprimer');
+        $repo->save($todo);
+
+        // findById
+        $found = $repo->findById($todo->getId()->toString());
+        $this->assertNotNull($found);
+        $this->assertEquals($todo->getTitle(), $found->getTitle());
+
+        //delete
+        $repo->delete($todo->getId()->toString());
+        $this->assertNull($repo->findById($todo->getId()->toString()));
+    }
+}

--- a/tests/Unit/Todo/Domain/TodoIdTest.php
+++ b/tests/Unit/Todo/Domain/TodoIdTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\Domain;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Todo\ValueObject\TodoId;
+use Ramsey\Uuid\Uuid;
+
+class TodoIdTest extends TestCase
+{
+    public function testShouldGenerateValidUuid()
+    {
+        $id = TodoId::generate();
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            $id->toString(),
+            'Le format du UUID généré n’est pas valide'
+        );
+    }
+
+    public function testShouldConvertFromStringAndToString()
+    {
+        $uuidString = Uuid::uuid4()->toString();
+        $id1 = TodoId::fromString($uuidString);
+        $id2 = TodoId::fromString($id1->toString());
+
+        $this->assertEquals($uuidString, $id1->toString());
+        $this->assertEquals($id1->toString(), $id2->toString());
+    }
+
+    public function testShouldBeEqualByValue()
+    {
+        $uuidString = Uuid::uuid4()->toString();
+        $a = TodoId::fromString($uuidString);
+        $b = TodoId::fromString($uuidString);
+
+        $this->assertTrue($a->toString() === $b->toString(), 'Deux TodoId avec même chaîne doivent être égaux');
+    }
+
+    public function testShouldRejectInvalidUuid()
+    {
+        $this->expectException(\Ramsey\Uuid\Exception\InvalidUuidStringException::class);
+        TodoId::fromString('not-a-uuid');
+    }
+}

--- a/tests/Unit/Todo/Domain/TodoTest.php
+++ b/tests/Unit/Todo/Domain/TodoTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Domain;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Todo\Entity\Todo;
+use App\Domain\Todo\ValueObject\TodoId;
+
+class TodoTest extends TestCase
+{
+    public function testShouldCreateTodoWithCorrectData()
+    {
+        $title = 'Faire les courses';
+        $todo  = Todo::create($title);
+
+        $this->assertMatchesRegularExpression(
+            '/' . TodoId::fromString($todo->getId()->toString())->toString() . '/',
+            $todo->getId()->toString()
+        );
+        $this->assertEquals('Faire les courses', $todo->getTitle());
+        $this->assertFalse($todo->isCompleted());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $todo->getCreatedAt());
+        $this->assertLessThan(
+            5,
+            (new \DateTimeImmutable())->getTimestamp() - $todo->getCreatedAt()->getTimestamp()
+        );
+    }
+
+    public function testShouldReconstructTodoWithCorrectData()
+    {
+        $id = TodoId::generate()->toString();
+        $title = 'Écrire un test';
+        $completed = true;
+        $createdAt = new \DateTimeImmutable('2025-04-01T12:34:56+00:00');
+
+        $todo = Todo::reconstruct(
+            $id,
+            $title,
+            $completed,
+            $createdAt
+        );
+
+        $this->assertEquals($id, $todo->getId()->toString());
+        $this->assertEquals($title, $todo->getTitle());
+        $this->assertTrue($todo->isCompleted());
+        $this->assertEquals($createdAt, $todo->getCreatedAt());
+    }
+
+    public function testShouldMarkAsCompleted()
+    {
+        $todo = Todo::create('Faire la vaisselle');
+        $this->assertFalse($todo->isCompleted());
+
+        $todo->markAsCompleted();
+        $this->assertTrue($todo->isCompleted());
+    }
+
+    public function testShouldHaveUniqueIds()
+    {
+        $todo1 = Todo::create('Tâche 1');
+        $todo2 = Todo::create('Tâche 2');
+
+        $this->assertNotEquals(
+            $todo1->getId()->toString(),
+            $todo2->getId()->toString(),
+            'Chaque Todo créé doit avoir un ID différent'
+        );
+    }
+}

--- a/tests/Unit/Todo/Mappers/EntityToTodoModelTest.php
+++ b/tests/Unit/Todo/Mappers/EntityToTodoModelTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Mappers;
+
+use PHPUnit\Framework\TestCase;
+use App\Infrastructure\Persistence\Todo\Eloquent\Mappers\EntityToTodoModel;
+use App\Infrastructure\Persistence\Todo\Eloquent\Models\TodoModel;
+use App\Domain\Todo\Entity\Todo;
+
+class EntityToTodoModelTest extends TestCase
+{
+    public function testMapCreatesModelWithCorrectAttributes(): void
+    {
+        $title = 'Mapping Test';
+        $todo  = Todo::create($title);
+
+        $model = EntityToTodoModel::map($todo);
+
+        $this->assertInstanceOf(TodoModel::class, $model);
+
+        $this->assertSame($todo->getId()->toString(), $model->id);
+        $this->assertSame('Mapping Test', $model->title);
+        $this->assertFalse($model->completed);
+    }
+}

--- a/tests/Unit/Todo/Mappers/TodoInputMapperTest.php
+++ b/tests/Unit/Todo/Mappers/TodoInputMapperTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Mappers;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\DTO\CreateTodoInput;
+use App\Application\Todo\Mappers\TodoInputMapper;
+use App\Domain\Todo\Entity\Todo;
+
+class TodoInputMapperTest extends TestCase
+{
+    public function testShouldConvertDtoToEntity()
+    {
+        $dto = new CreateTodoInput(title: 'Mon titre de test');
+
+        $todo = TodoInputMapper::toEntity($dto);
+
+        $this->assertInstanceOf(Todo::class, $todo);
+    }
+
+    public function testShouldConvertDtoToEntityWithCorrectData()
+    {
+        $dto = new CreateTodoInput(title: 'Mon titre de test');
+
+        $todo = TodoInputMapper::toEntity($dto);
+
+        $this->assertEquals('Mon titre de test', $todo->getTitle());
+        $this->assertFalse($todo->isCompleted());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $todo->getCreatedAt());
+        $this->assertLessThan(
+            5,
+            (new \DateTimeImmutable())->getTimestamp()
+            - $todo->getCreatedAt()->getTimestamp(),
+            'Le createdAt doit être dans les 5 secondes précédentes'
+        );
+    }
+}

--- a/tests/Unit/Todo/Mappers/TodoModelToEntityTest.php
+++ b/tests/Unit/Todo/Mappers/TodoModelToEntityTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit\Mappers;
+
+use PHPUnit\Framework\TestCase;
+use App\Infrastructure\Persistence\Todo\Eloquent\Mappers\TodoModelToEntity;
+use App\Infrastructure\Persistence\Todo\Eloquent\Models\TodoModel;
+use App\Domain\Todo\Entity\Todo;
+use Illuminate\Support\Carbon;
+
+class TodoModelToEntityTest extends TestCase
+{
+    public function testShouldConvertModelToEntity()
+    {
+        $model = new TodoModel();
+        $model->setRawAttributes([
+            'id'         => '123e4567-e89b-12d3-a456-426614174000',
+            'title'      => 'Un titre',
+            'completed'  => true,
+            'created_at' => Carbon::parse('2025-04-17 12:00:00', 'UTC'),
+        ], /* sync = */ true);
+
+        $todo = TodoModelToEntity::map($model);
+
+        $this->assertInstanceOf(Todo::class, $todo);
+        $this->assertSame($model->id, $todo->getId()->toString());
+        $this->assertSame('Un titre', $todo->getTitle());
+        $this->assertTrue($todo->isCompleted());
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $todo->getCreatedAt());
+        $expected = $model->created_at->toDateTimeImmutable()->format(\DateTime::ATOM);
+        $this->assertEquals($expected, $todo->getCreatedAt()->format(\DateTime::ATOM));
+    }
+}

--- a/tests/Unit/Todo/Mappers/TodoOutputMapperTest.php
+++ b/tests/Unit/Todo/Mappers/TodoOutputMapperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\Mappers;
+
+use PHPUnit\Framework\TestCase;
+use App\Domain\Todo\Entity\Todo;
+use App\Application\Todo\Mappers\TodoOutputMapper;
+use App\Application\Todo\DTO\TodoOutput;
+
+class TodoOutputMapperTest extends TestCase
+{
+    public function testShouldConvertEntityToDto()
+    {
+        $todo  = Todo::create('Titre de test');
+
+        $dto = TodoOutputMapper::toDto($todo);
+
+        $this->assertInstanceOf(TodoOutput::class, $dto);
+    }
+
+    public function testShouldConvertEntityToDtoWithCorrectData()
+    {
+        $todo = Todo::create('Titre de test');
+        $dto = TodoOutputMapper::toDto($todo);
+
+        $this->assertEquals(
+            $todo->getId()->toString(),
+            $dto->id,
+            'L’ID du DTO doit correspondre à celui de l’entité'
+        );
+
+        $this->assertEquals(
+            'Titre de test',
+            $dto->title,
+            'Le titre du DTO doit correspondre à celui de l’entité'
+        );
+
+        $this->assertFalse(
+            $dto->completed,
+            'Le champ completed du DTO doit refléter l’état de l’entité'
+        );
+
+        $this->assertEquals(
+            $todo->getCreatedAt()->format(\DateTime::ATOM),
+            $dto->createdAt,
+            'Le createdAt doit être formaté en DateTime::ATOM'
+        );
+    }
+}

--- a/tests/Unit/Todo/UseCases/CompleteTodoTest.php
+++ b/tests/Unit/Todo/UseCases/CompleteTodoTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\UseCases\CompleteTodo;
+use App\Domain\Todo\TodoRepository;
+use App\Domain\Todo\Entity\Todo;
+
+class CompleteTodoTest extends TestCase
+{
+    public function testShouldMarkTodoAsCompleted()
+    {
+        $id   = '123e4567-e89b-12d3-a456-426614174000';
+        $todo = Todo::reconstruct(
+            id:        $id,
+            title:     'à compléter',
+            completed: false,
+            createdAt: new \DateTimeImmutable()
+        );
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('findById')
+             ->with($id)
+             ->willReturn($todo);
+
+        $repo->expects($this->once())
+             ->method('update')
+             ->with($this->callback(function (Todo $t) use ($id) {
+                 return $t->getId()->toString() === $id
+                     && $t->isCompleted() === true;
+             }));
+
+        $useCase = new CompleteTodo($repo);
+        $useCase->execute($id);
+    }
+
+    public function testShouldThrowWhenTodoNotFound()
+    {
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->method('findById')
+             ->willReturn(null);
+
+        $this->expectException(\DomainException::class);
+
+        $useCase = new CompleteTodo($repo);
+        $useCase->execute('non-existent-id');
+    }
+}

--- a/tests/Unit/Todo/UseCases/CreateTodoTest.php
+++ b/tests/Unit/Todo/UseCases/CreateTodoTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\UseCases\CreateTodo;
+use App\Application\Todo\DTO\CreateTodoInput;
+use App\Application\Todo\DTO\TodoOutput;
+use App\Domain\Todo\TodoRepository;
+
+class CreateTodoTest extends TestCase
+{
+    public function testShouldSaveTodo()
+    {
+        $dto = new CreateTodoInput(title: 'Titre');
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('save');
+
+        $useCase = new CreateTodo($repo);
+        $useCase->execute($dto);
+    }
+
+    public function testShouldReturnDtoWithCorrectData()
+    {
+        $dto = new CreateTodoInput(title: 'Titre');
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+            ->method('save');
+
+        $useCase = new CreateTodo($repo);
+        $output  = $useCase->execute($dto);
+
+        $this->assertInstanceOf(TodoOutput::class, $output);
+        $this->assertEquals($dto->title, $output->title);
+        $this->assertFalse($output->completed);
+        $this->assertNotEmpty($output->id);
+        $this->assertMatchesRegularExpression(
+            '/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/',
+            $output->createdAt
+        );
+    }
+}

--- a/tests/Unit/Todo/UseCases/DeleteTodoTest.php
+++ b/tests/Unit/Todo/UseCases/DeleteTodoTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\UseCases\DeleteTodo;
+use App\Domain\Todo\TodoRepository;
+
+class DeleteTodoTest extends TestCase
+{
+    public function testShouldDeleteTodo()
+    {
+        $id   = '123e4567-e89b-12d3-a456-426614174000';
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('delete')
+             ->with($id);
+
+        $useCase = new DeleteTodo($repo);
+        $useCase->execute($id);
+    }
+}

--- a/tests/Unit/Todo/UseCases/FindTodoTest.php
+++ b/tests/Unit/Todo/UseCases/FindTodoTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\UseCases\FindTodo;
+use App\Domain\Todo\TodoRepository;
+use App\Domain\Todo\Entity\Todo;
+use App\Application\Todo\DTO\TodoOutput;
+class FindTodoTest extends TestCase
+{
+    public function testShouldFindTodo()
+    {
+        $id   = '123e4567-e89b-12d3-a456-426614174000';
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('findById');
+
+        $useCase = new FindTodo($repo);
+        $useCase->execute($id);
+    }
+
+    public function testShouldReturnNullIfTodoNotFound()
+    {
+        $id   = '123e4567-e89b-12d3-a456-426614174000';
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('findById')
+             ->willReturn(null);
+
+        $useCase = new FindTodo($repo);
+        $result = $useCase->execute($id);
+
+        $this->assertNull($result);
+    }
+
+    public function testShouldReturnTodoOutput()
+    {
+        $id   = '123e4567-e89b-12d3-a456-426614174000';
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('findById')
+             ->willReturn(Todo::create('Test'));
+
+        $useCase = new FindTodo($repo);
+        $result = $useCase->execute($id);
+
+        $this->assertInstanceOf(TodoOutput::class, $result);
+    }
+}

--- a/tests/Unit/Todo/UseCases/ListTodosTest.php
+++ b/tests/Unit/Todo/UseCases/ListTodosTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit\UseCases;
+
+use PHPUnit\Framework\TestCase;
+use App\Application\Todo\UseCases\ListTodos;
+use App\Application\Todo\DTO\TodoOutput;
+use App\Domain\Todo\TodoRepository;
+use App\Domain\Todo\Entity\Todo;
+
+class ListTodosTest extends TestCase
+{
+    public function testShouldListTodos()
+    {
+        $t1 = Todo::create('tâche 1');
+        $t2 = Todo::create('tâche 2');
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->expects($this->once())
+             ->method('findAll')
+             ->willReturn([$t1, $t2]);
+
+        $useCase = new ListTodos($repo);
+        $useCase->execute();
+    }
+
+    public function testShouldReturnMappedTodoOutputs()
+    {
+        $t1 = Todo::create('tâche 1');
+        $t2 = Todo::create('tâche 2');
+
+        $repo = $this->createMock(TodoRepository::class);
+        $repo->method('findAll')
+             ->willReturn([$t1, $t2]);
+
+        $useCase = new ListTodos($repo);
+        $result  = $useCase->execute();
+
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(TodoOutput::class, $result[0]);
+        $this->assertEquals('tâche 1', $result[0]->title);
+        $this->assertEquals('tâche 2', $result[1]->title);
+    }
+}


### PR DESCRIPTION
This pull request introduces a comprehensive set of unit and integration tests for the `Todo` domain, covering repositories, entities, mappers, and use cases. The changes ensure robust testing for core functionalities like creating, updating, deleting, and retrieving todos, as well as mapping between entities and data transfer objects (DTOs).

### Integration Tests

* **Eloquent Repository Tests**: Added integration tests for the `EloquentTodoRepository` to verify CRUD operations (`tests/Integration/Todo/EloquentTodoRepositoryTest.php`).
* **File Repository Tests**: Added integration tests for the `FileTodoRepository` to validate functionality with file-based storage (`tests/Integration/Todo/FileTodoRepositoryTest.php`).

### Unit Tests for Domain

* **Todo Entity Tests**: Added unit tests for the `Todo` entity to validate creation, reconstruction, state changes, and unique IDs (`tests/Unit/Todo/Domain/TodoTest.php`).
* **TodoId Tests**: Added unit tests for the `TodoId` value object to ensure UUID generation, equality checks, and rejection of invalid UUIDs (`tests/Unit/Todo/Domain/TodoIdTest.php`).

### Unit Tests for Mappers

* **Entity to Model**: Added tests for `EntityToTodoModel` to ensure correct mapping of domain entities to database models (`tests/Unit/Todo/Mappers/EntityToTodoModelTest.php`).
* **Model to Entity**: Added tests for `TodoModelToEntity` to validate conversion of database models back to domain entities (`tests/Unit/Todo/Mappers/TodoModelToEntityTest.php`).
* **Input and Output Mappers**: Added tests for `TodoInputMapper` and `TodoOutputMapper` to verify DTO-to-entity and entity-to-DTO transformations (`tests/Unit/Todo/Mappers/TodoInputMapperTest.php`, `tests/Unit/Todo/Mappers/TodoOutputMapperTest.php`). [[1]](diffhunk://#diff-23f040f5896f8722ac4706966f0f040944494af482dfc5a3df9cc06d8cf1e755R1-R37) [[2]](diffhunk://#diff-325f2e20e46e3f23643e0c6b93e48169b62a816eec56de1f64b5dc402af1a250R1-R49)

### Unit Tests for Use Cases

* **CreateTodo**: Added tests for the `CreateTodo` use case to validate saving and returning correct DTO data (`tests/Unit/Todo/UseCases/CreateTodoTest.php`).
* **CompleteTodo**: Added tests for the `CompleteTodo` use case to ensure todos are marked as completed and exceptions are thrown for invalid IDs (`tests/Unit/Todo/UseCases/CompleteTodoTest.php`).
* **DeleteTodo**: Added tests for the `DeleteTodo` use case to confirm deletion functionality (`tests/Unit/Todo/UseCases/DeleteTodoTest.php`).
* **FindTodo**: Added tests for the `FindTodo` use case to handle finding todos, returning DTOs, and null for nonexistent todos (`tests/Unit/Todo/UseCases/FindTodoTest.php`).
* **ListTodos**: Added tests for the `ListTodos` use case to verify listing and mapping of todos to DTOs (`tests/Unit/Todo/UseCases/ListTodosTest.php`).